### PR TITLE
registry.pol parser first commit

### DIFF
--- a/Grouper2/Assess/AssessHandlers.cs
+++ b/Grouper2/Assess/AssessHandlers.cs
@@ -7,6 +7,24 @@ namespace Grouper2
 {
     class AssessHandlers
     {
+        // Assesses the contents of a registry.pol
+        public static JObject AssessRegistryPol(JObject registryPolToAssess)
+        {
+            Dictionary<string, JObject> assessedRegistryPol = new Dictionary<string, JObject>();
+
+            if (registryPolToAssess != null)
+            {
+                JObject matchedRegValues = InfAssess.AssessInf.AssessRegValues(registryPolToAssess);
+                if (matchedRegValues != null)
+                {
+                    assessedRegistryPol.Add("Registry Values", matchedRegValues);
+                }
+            }
+
+            JObject assessedRegistryPolJson = (JObject)JToken.FromObject(assessedRegistryPol);
+            return assessedRegistryPolJson;
+        }
+
         // Assesses the contents of a GPTmpl
         public static JObject AssessGptmpl(JObject infToAssess)
         {

--- a/Grouper2/Grouper2.csproj
+++ b/Grouper2/Grouper2.csproj
@@ -104,6 +104,7 @@
     <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Assess\InfAssess\AssessRegValues.cs" />
     <Compile Include="Utility\CurrentUserSecurity.cs" />
     <Compile Include="Utility\FileSystem.cs" />
     <Compile Include="Assess\GPPAssess\AssessGpp.cs" />
@@ -111,6 +112,7 @@
     <Compile Include="Utility\JUtil.cs" />
     <Compile Include="Utility\Output.cs" />
     <Compile Include="Assess\PackageAssess\PackageAssess.cs" />
+    <Compile Include="Utility\RegistryPolParser.cs" />
     <Compile Include="Utility\SddlParser\ParseSDDL.cs" />
     <Compile Include="Assess\ScriptsIniAssess\AssessScriptsIni.cs" />
     <Compile Include="Assess\GPPAssess\AssessDataSources.cs" />
@@ -130,7 +132,6 @@
     <Compile Include="Assess\InfAssess\AssessKerbPolicy.cs" />
     <Compile Include="Assess\InfAssess\AssessPrivRights.cs" />
     <Compile Include="Assess\InfAssess\AssessRegKeys.cs" />
-    <Compile Include="Assess\InfAssess\AssessRegValues.cs" />
     <Compile Include="Assess\InfAssess\AssessServiceGenSetting.cs" />
     <Compile Include="Assess\InfAssess\AssessSysAccess.cs" />
     <Compile Include="LDAPstuff.cs" />

--- a/Grouper2/Parsers.cs
+++ b/Grouper2/Parsers.cs
@@ -269,6 +269,11 @@ namespace Grouper2
             // return the JObject
             return parsedXmlFileToJson;
         }
+
+        public static JObject ParseRegistryPol(string registryFile)
+        {
+            return RegistryPolParser.Read(registryFile);
+        }
     }
 }
  

--- a/Grouper2/Utility/RegistryPolParser.cs
+++ b/Grouper2/Utility/RegistryPolParser.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Win32;
+using Newtonsoft.Json.Linq;
+
+namespace Grouper2.Utility
+{
+	// Stripped down version of https://github.com/finarfin/GroupPolicy.Parser/blob/master/RegistryFile.cs
+	// Very light / basic registry.pol parser.
+	// Refactored to allow re-use of InfAssess code in the AssessHandlers
+	public class RegistryPolParser
+	{
+		private const uint SIGNATURE = 0x67655250; // "PReg"
+
+		public static JObject Read(string path)
+		{
+			// Store the parsed data
+			var result = new JObject();
+
+			// Open the file
+			using (var file = File.OpenRead(path))
+			using (var reader = new BinaryReader(file, Encoding.Unicode))
+			{
+				// Check against the file signature
+				var Signature = reader.ReadUInt32();
+				if (Signature != SIGNATURE)
+				{
+					throw new NotSupportedException("File format is not supported");
+				}
+
+				// Get the file version
+				var version = reader.ReadUInt32();
+
+				// Get the length of the file
+				var length = reader.BaseStream.Length;
+
+				// Read the contents
+				while (reader.BaseStream.Position < length)
+				{
+					// Storing properties of the key / value in this object to match the infAssess format
+					List<object> values = new List<object>();
+
+					reader.ReadChar();
+					var name = ReadString(reader);	// This is the Reg key
+					reader.ReadChar();
+					name += "\\" + ReadString(reader); // This is the value
+					reader.ReadChar();
+					values.Add(reader.ReadUInt32()); // This is the value type
+					reader.ReadChar();
+					var size = reader.ReadUInt32(); // This is the size of the value data
+					reader.ReadChar();
+					byte[] binaryData = reader.ReadBytes((int)size); // value data
+					reader.ReadChar();
+
+					// Convert the raw data into a usable format
+					GetData(binaryData, ref values);
+
+					// Turn that list of properties into an array
+					object[] value = values.ToArray();
+
+					// The name of the key\value becomes a new property of the output object
+					// and the data about the value (type, actual value data) are an array
+					result[name] = JArray.FromObject(value);
+				}
+			}
+
+			return result;
+		}
+
+		// Reads a null terminated string from a binary stream.
+		private static string ReadString(BinaryReader reader)
+		{
+			char current;
+			string temp = string.Empty;
+			while ((current = reader.ReadChar()) != '\0')
+			{
+				temp += current;
+			}
+
+			return temp;
+		}
+
+		// converts the raw binary value data into a usable format
+		private static void GetData(byte[] binaryData, ref List<object> values)
+		{
+			UInt32 type = (UInt32)values[0];
+			switch ((RegistryValueKind)type)
+			{
+				case RegistryValueKind.String:
+				case RegistryValueKind.ExpandString:
+					values.Add(Encoding.Unicode.GetString(binaryData).TrimEnd('\0'));
+					return;
+
+				case RegistryValueKind.DWord:
+					values.Add(BitConverter.ToUInt32(binaryData, 0));
+					return;
+
+				case RegistryValueKind.QWord:
+					values.Add(BitConverter.ToUInt64(binaryData, 0));
+					return;
+
+				case RegistryValueKind.MultiString:
+					if (binaryData.Length == 0) return;
+
+					var collection = new List<string>();
+					using (var stream = new MemoryStream(binaryData))
+					using (var reader = new BinaryReader(stream, Encoding.Unicode))
+					{
+						var length = reader.BaseStream.Length;
+						while (reader.BaseStream.Position < length)
+						{
+							values.Add(ReadString(reader));
+							if (reader.PeekChar() == '\0')
+								break;
+						}
+						return;
+					}
+
+				default:
+					values.Add(binaryData);
+					return;
+			}
+		}
+	}
+}


### PR DESCRIPTION
### This PR is an attempt to fix issue #10.

**Disclaimer: This definitely wants a grown up to look at it**

registry.pol parser code is based heavily on https://github.com/finarfin/GroupPolicy.Parser, modified so that the output is in the right format to reuse the AssessHandler code in AssessRegValues.cs. I've tested on an honest-to-god registry.pol file iin offline mode and it:

1. Correctly parsed the file
2. Detected a test issue that I added to PolData.txt

Parser was bolted onto G2 assuming that Machine/registry.pol and User/registry.pol are going to live under the Policies folder on SYSVOL. I actually have no idea if this was a correct assumption to make, so if that's not where these files live then I might need some grown-up guidance on where to look.

I've also left adding interesting registry keys into PolData.txt out of scope (referring to the comment on the ticket "From what I can tell the contents include stuff like the windows firewall policy but there's probably other goodies in there too").

I hope the PR is usable, let me know what needs to be done if not. Saw [this tweet](https://twitter.com/mikeloss/status/1372489027794857987?s=20) and thought I might try to knock something small off the to-do list.

Cheers!